### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/scripts/instantiate-code-fonts.py
+++ b/scripts/instantiate-code-fonts.py
@@ -40,7 +40,7 @@ except IndexError:
     fontPath =  glob.glob('./font-data/Recursive_VF_*.ttf')[0] # allows script to run without font path passed in.
 
 # read yaml config
-with open(configPath) as file:
+with open(configPath, encoding='utf-8') as file:
     fontOptions = yaml.load(file, Loader=yaml.FullLoader)
 
 # GET / SET NAME HELPER FUNCTIONS


### PR DESCRIPTION
There is a UnicodeDecodeError when I run the build script. I run the build script on my Windows system which system language is Chinese.

I think it's an encoding problem. Add encoding=utf-8 to avoid encoding issues.

<img width="866" alt="屏幕截图 2023-05-12 142836" src="https://github.com/arrowtype/recursive-code-config/assets/71315026/84d1b8a2-df74-44f9-bf7b-c01376c13bf9">
